### PR TITLE
added QT_DECL_EXPORT/QT_DECL_IMPORT to allow building DLLs

### DIFF
--- a/SMTPEmail.pro
+++ b/SMTPEmail.pro
@@ -7,8 +7,13 @@
 QT       += core gui network
 
 TARGET = SMTPEmail
-TEMPLATE = app
 
+TEMPLATE = app
+# uncomment this to build a shared library
+#TEMPLATE = lib
+#CONFIG += dll
+
+DEFINES += SMTP_BUILD
 
 SOURCES += \
     src/emailaddress.cpp \
@@ -37,7 +42,8 @@ HEADERS  += \
     src/SmtpMime \
     src/quotedprintable.h \
     src/mimemultipart.h \
-    src/mimecontentformatter.h
+    src/mimecontentformatter.h \
+    src/smtpexports.h
 
 OTHER_FILES += \
     LICENSE \

--- a/src/emailaddress.h
+++ b/src/emailaddress.h
@@ -21,7 +21,9 @@
 
 #include <QObject>
 
-class EmailAddress : public QObject
+#include "smtpexports.h"
+
+class SMTP_EXPORT EmailAddress : public QObject
 {
     Q_OBJECT
 public:

--- a/src/mimeattachment.h
+++ b/src/mimeattachment.h
@@ -23,7 +23,9 @@
 #include "mimepart.h"
 #include "mimefile.h"
 
-class MimeAttachment : public MimeFile
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeAttachment : public MimeFile
 {
     Q_OBJECT
 public:

--- a/src/mimecontentformatter.h
+++ b/src/mimecontentformatter.h
@@ -22,7 +22,9 @@
 #include <QObject>
 #include <QByteArray>
 
-class MimeContentFormatter : public QObject
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeContentFormatter : public QObject
 {
     Q_OBJECT
 public:

--- a/src/mimefile.h
+++ b/src/mimefile.h
@@ -22,7 +22,9 @@
 #include "mimepart.h"
 #include <QFile>
 
-class MimeFile : public MimePart
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeFile : public MimePart
 {
     Q_OBJECT
 public:

--- a/src/mimehtml.h
+++ b/src/mimehtml.h
@@ -21,7 +21,9 @@
 
 #include "mimetext.h"
 
-class MimeHtml : public MimeText
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeHtml : public MimeText
 {
     Q_OBJECT
 public:

--- a/src/mimeinlinefile.h
+++ b/src/mimeinlinefile.h
@@ -21,7 +21,9 @@
 
 #include "mimefile.h"
 
-class MimeInlineFile : public MimeFile
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeInlineFile : public MimeFile
 {
 public:
 

--- a/src/mimemessage.h
+++ b/src/mimemessage.h
@@ -24,7 +24,9 @@
 #include "emailaddress.h"
 #include <QList>
 
-class MimeMessage : public QObject
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeMessage : public QObject
 {
 public:
 

--- a/src/mimemultipart.h
+++ b/src/mimemultipart.h
@@ -21,7 +21,9 @@
 
 #include "mimepart.h"
 
-class MimeMultiPart : public MimePart
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeMultiPart : public MimePart
 {
     Q_OBJECT
 public:

--- a/src/mimepart.h
+++ b/src/mimepart.h
@@ -22,7 +22,9 @@
 #include <QObject>
 #include "mimecontentformatter.h"
 
-class MimePart : public QObject
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimePart : public QObject
 {
     Q_OBJECT
 public:

--- a/src/mimetext.h
+++ b/src/mimetext.h
@@ -21,7 +21,9 @@
 
 #include "mimepart.h"
 
-class MimeText : public MimePart
+#include "smtpexports.h"
+
+class SMTP_EXPORT MimeText : public MimePart
 {
 public:
 

--- a/src/quotedprintable.h
+++ b/src/quotedprintable.h
@@ -22,7 +22,9 @@
 #include <QObject>
 #include <QByteArray>
 
-class QuotedPrintable : public QObject
+#include "smtpexports.h"
+
+class SMTP_EXPORT QuotedPrintable : public QObject
 {
     Q_OBJECT
 public:

--- a/src/smtpclient.h
+++ b/src/smtpclient.h
@@ -23,9 +23,9 @@
 #include <QtNetwork/QSslSocket>
 
 #include "mimemessage.h"
+#include "smtpexports.h"
 
-
-class SmtpClient : public QObject
+class SMTP_EXPORT SmtpClient : public QObject
 {
     Q_OBJECT
 public:

--- a/src/smtpexports.h
+++ b/src/smtpexports.h
@@ -1,0 +1,10 @@
+#ifndef SMTPEXPORTS_H
+#define SMTPEXPORTS_H
+
+#ifdef SMTP_BUILD
+#define SMTP_EXPORT Q_DECL_EXPORT
+#else
+#define SMTP_EXPORT Q_DECL_IMPORT
+#endif
+
+#endif // SMTPEXPORTS_H


### PR DESCRIPTION
Hi,
to be able to comply with the LGPL license, I need to be able to build the smtp client as a DLL on Windows. I added the necessary QT_DECL_\* declarations for this. On Linux, they don't do anything, but on Windows they lead to the respective symbols being exported from the DLL.

Cheers
