### PR TITLE
Add date header field in RFC2822 format to MimeMessage

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -249,6 +249,7 @@ QString MimeMessage::toString()
 
     mime += "\r\n";
     mime += "MIME-Version: 1.0\r\n";
+    mime += QString("Date: %1\r\n").arg(QDateTime::currentDateTime().toString(Qt::RFC2822Date));
 
     mime += content->toString();
     return mime;


### PR DESCRIPTION
Some email servers are get unhappy if the date header attribute is not set