### PR TITLE
Caught SmtpClient::SendMessageTimeoutException

### DIFF
--- a/src/smtpclient.cpp
+++ b/src/smtpclient.cpp
@@ -420,7 +420,16 @@ bool SmtpClient::sendMail(MimeMessage& email)
 
 void SmtpClient::quit()
 {
-    sendMessage("QUIT");
+    try 
+    {
+        sendMessage("QUIT");
+    }
+    catch(SmtpClient::SendMessageTimeoutException) 
+    {
+	//Manually close the connection to the smtp server if message "QUIT" wasn't received by the smtp server
+        if(socket->state() == QAbstractSocket::ConnectedState || socket->state() == QAbstractSocket::ConnectingState || socket->state() == QAbstractSocket::HostLookupState)
+            socket->disconnectFromHost();
+    }
 }
 
 /* [3] --- */


### PR DESCRIPTION
In Smtp::quit, SmtpClient::SendMessageTimeoutException is caught and if still connected to the smtp server, manually close
the connection.