### PR TITLE
Fixed Qt4 compilation for version 1.1. Works with MSVC2013. (#62)

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -24,7 +24,7 @@
 
 /* [1] Constructors and Destructors */
 MimeMessage::MimeMessage(bool createAutoMimeContent) :
-    replyTo(Q_NULLPTR),
+    replyTo(nullptr),
     hEncoding(MimePart::_8Bit)
 {
     if (createAutoMimeContent)
@@ -37,8 +37,8 @@ MimeMessage::~MimeMessage()
 {
     if (this->autoMimeContentCreated)
     {
-      this->autoMimeContentCreated = false;
-      delete (this->content);
+        this->autoMimeContentCreated = false;
+        delete (this->content);
     }
 }
 
@@ -53,8 +53,8 @@ MimePart& MimeMessage::getContent() {
 void MimeMessage::setContent(MimePart *content) {
     if (this->autoMimeContentCreated)
     {
-      this->autoMimeContentCreated = false;
-      delete (this->content);
+        this->autoMimeContentCreated = false;
+        delete (this->content);
     }
     this->content = content;
 }
@@ -293,7 +293,12 @@ QString MimeMessage::toString()
         mime += "In-Reply-To: <" + mInReplyTo + ">\r\n";
         mime += "References: <" + mInReplyTo + ">\r\n";
     }
+
+#if QT_MAJOR_VERSION < 5 //Qt4 workaround since RFC2822Date isn't defined
+    mime += QString("Date: %1\r\n").arg(QDateTime::currentDateTime().toString("dd MMM yyyy hh:mm:ss +/-TZ"));
+#elif //Qt5 supported
     mime += QString("Date: %1\r\n").arg(QDateTime::currentDateTime().toString(Qt::RFC2822Date));
+#endif //support RFC2822Date
 
     mime += content->toString();
     return mime;


### PR DESCRIPTION
Qt4 doesn't have `Q_NULLPTR` defined, nor does it support RFC2822Date. I manually constructed the `RFC2822Date` if `QT_MAJOR_VERSION < 5` based on the Qt5 source and replaced `Q_NULLPTR` with `nullptr`. Worked for me using MSVC2013 as my compiler.

I think my Qt Creator style also fixed indentation for a couple lines.