### PR TITLE
remove stray space after colon following MAIL FROM and RCPT TO

### DIFF
--- a/src/smtpclient.cpp
+++ b/src/smtpclient.cpp
@@ -353,7 +353,7 @@ bool SmtpClient::sendMail(MimeMessage& email)
     try
     {
         // Send the MAIL command with the sender
-        sendMessage("MAIL FROM: <" + email.getSender().getAddress() + ">");
+        sendMessage("MAIL FROM:<" + email.getSender().getAddress() + ">");
 
         waitForResponse();
 
@@ -386,7 +386,7 @@ bool SmtpClient::sendMail(MimeMessage& email)
         for (it = email.getRecipients(MimeMessage::Bcc).begin(), itEnd = email.getRecipients(MimeMessage::Bcc).end();
              it != itEnd; ++it)
         {
-            sendMessage("RCPT TO: <" + (*it)->getAddress() + ">");
+            sendMessage("RCPT TO:<" + (*it)->getAddress() + ">");
             waitForResponse();
 
             if (responseCode != 250) return false;


### PR DESCRIPTION
Quoth https://www.ietf.org/rfc/rfc5321.txt:

   Since it has been a common source of errors, it is worth noting that
   spaces are not permitted on either side of the colon following FROM
   in the MAIL command or TO in the RCPT command.  The syntax is exactly
   as given above.