### PR TITLE
compiling fix, -std=c++0x added into the qmake .pro file

### DIFF
--- a/SMTPEmail.pro
+++ b/SMTPEmail.pro
@@ -4,6 +4,8 @@
 #
 #-------------------------------------------------
 
+CONFIG	+= c++11
+
 QT       += core network
 
 TARGET = SMTPEmail


### PR DESCRIPTION
added -std=c++0x g++ option to qmake file.
issue #74 