### PR TITLE
<fix>(project): support static build.

### DIFF
--- a/src/smtpexports.h
+++ b/src/smtpexports.h
@@ -3,8 +3,10 @@
 
 #ifdef SMTP_BUILD
 #define SMTP_EXPORT Q_DECL_EXPORT
-#else
+#elseif SMTP_USE
 #define SMTP_EXPORT Q_DECL_IMPORT
+#else
+#define SMTP_EXPORT
 #endif
 
 #endif // SMTPEXPORTS_H


### PR DESCRIPTION
Sometimes users don't want to export symbols to dynamic libraries. You may need to provide such an option.