### PR TITLE
Fixed encoding issue in `MimeText::writeContent()`

### DIFF
--- a/src/mimetext.cpp
+++ b/src/mimetext.cpp
@@ -51,7 +51,19 @@ const QString & MimeText::getText() const
 /* [3] Protected Methods */
 
 void MimeText::writeContent(QIODevice &device) const {
-    MimePart::writeContent(device, text.toLocal8Bit());
+    switch (cEncoding)
+    {
+    case _7Bit:
+    case _8Bit:
+        MimePart::writeContent(device, text.toLocal8Bit());
+        break;
+    case Base64:
+        MimePart::writeContent(device, text.toUtf8());
+        break;
+    case QuotedPrintable:
+        MimePart::writeContent(device, text.toLatin1());
+        break;
+    }
 }
 
 /* [3] --- */


### PR DESCRIPTION
Strangely, this seems to have been in the 1.1 version already. In any case, this allows sending QString-messages with german Umlaute or other special chars.
