### PR TITLE
A few improvements for attachment files

### DIFF
--- a/src/mimeattachment.cpp
+++ b/src/mimeattachment.cpp
@@ -24,7 +24,7 @@
 MimeAttachment::MimeAttachment(QFile *file)
     : MimeFile(file)
 {
-    this->headerLines += "Content-disposition: attachment\r\n";
+    this->headerLines += "Content-disposition: attachment; filename=\"" + cName + "\"\r\n";
 }
 
 MimeAttachment::~MimeAttachment()

--- a/src/mimefile.cpp
+++ b/src/mimefile.cpp
@@ -18,14 +18,19 @@
 
 #include "mimefile.h"
 #include <QFileInfo>
+#include <QMimeDatabase>
+#include <QMimeType>
 
 /* [1] Constructors and Destructors */
 
 MimeFile::MimeFile(QFile *file)
 {
+    QFileInfo fileInfo(*file);
+    QMimeType mimeType = QMimeDatabase().mimeTypeForFile(fileInfo);
+
     this->file = file;
-    this->cType = "application/octet-stream";
-    this->cName = QFileInfo(*file).fileName();
+    this->cType = mimeType.name();
+    this->cName = fileInfo.fileName();
     this->cEncoding = Base64;
 }
 

--- a/src/mimepart.cpp
+++ b/src/mimepart.cpp
@@ -192,7 +192,7 @@ void MimePart::writeToDevice(QIODevice &device) const {
 
     /* === End of Header Prepare === */
 
-    device.write(header.toLatin1());
+    device.write(header.toUtf8());
 
     writeContent(device);
 }


### PR DESCRIPTION
Hello,

Thanks for a great library!

I am, however, proposing a few small improvements to how file attachments are handled:

1. Non-ascii characters in file names: These are not AFAIK allowed by the RFC but they still occur and it might be better to save them as utf-8 which e.g. gmail and Outlook seems to detect correctly.
2. Filename in the Content-disposition header as per RFC-2183.
3. Use QMimeDatabase to provide a better MIME type than application/octet-stream. This is such a simple improvement since QMimeDatabase is there already.


Kind Regards
Bjørn Thirud
