### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC
         # where top-level project will look for the library's public headers
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         # where external projects will look for the library's public headers
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/smtpmime>
 )


### PR DESCRIPTION
Missing the `>` for the `BUILD_INTERFACE` expression.

```
1> Error: CMake file API parsing response files failed. Check for invalid paths in your CMakeLists.txt files. Parsing failed when attempting to parse this path: "C:\\dev\\SmtpClient-for-Qt\\src\\$<BUILD_INTERFACE:C:\\dev\\SmtpClient-for-Qt\\s" +
    "rc"