### PR TITLE
Add Reply-To header support

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -59,6 +59,11 @@ void MimeMessage::setSender(const EmailAddress &sender)
     this->sender = sender;
 }
 
+void MimeMessage::setReplyTo(const EmailAddress &replyTo)
+{
+    this->replyTo = replyTo;
+}
+
 void MimeMessage::addRecipient(const EmailAddress &rcpt, RecipientType type)
 {
     switch (type)
@@ -112,6 +117,11 @@ void MimeMessage::setHeaderEncoding(MimePart::Encoding hEnc)
 EmailAddress MimeMessage::getSender() const
 {
     return sender;
+}
+
+EmailAddress MimeMessage::getReplyTo() const
+{
+    return replyTo;
 }
 
 const QList<EmailAddress> & MimeMessage::getRecipients(RecipientType type) const
@@ -191,6 +201,12 @@ void MimeMessage::writeToDevice(QIODevice &out) const {
     /* ---------- Sender / From ----------- */
     QByteArray header;
     header.append("From:" + formatAddress(sender, hEncoding) + "\r\n");
+    /* ---------------------------------- */
+
+    /* ---------- Reply-To ----------- */
+    if (!replyTo.getAddress().isEmpty()) {
+      header.append("Reply-To:" + formatAddress(replyTo, hEncoding) + "\r\n");
+    }
     /* ---------------------------------- */
 
     /* ------- Recipients / To ---------- */

--- a/src/mimemessage.h
+++ b/src/mimemessage.h
@@ -49,6 +49,7 @@ public:
     /* [2] Getters and Setters */
 
     void setSender(const EmailAddress &sndr);
+    void setReplyTo(const EmailAddress &repto);
     void addRecipient(const EmailAddress &rcpt, RecipientType type = To);
     void addTo(const EmailAddress &rcpt);
     void addCc(const EmailAddress &rcpt);
@@ -60,6 +61,7 @@ public:
     void setHeaderEncoding(MimePart::Encoding);
 
     EmailAddress getSender() const;
+    EmailAddress getReplyTo() const;
     const QList<EmailAddress> &getRecipients(RecipientType type = To) const;
     QString getSubject() const;
     const QStringList &getCustomHeaders() const;
@@ -82,6 +84,7 @@ protected:
     /* [4] Protected members */
 
     EmailAddress sender;
+    EmailAddress replyTo;
     QList<EmailAddress> recipientsTo, recipientsCc, recipientsBcc;
     QString subject;
     QStringList customHeaders;


### PR DESCRIPTION
I had the impression that the ReplyTo header has the same value as the other standard headers related to sender and recipients. We have therefore added methods that allow this header to be set and queried. Best regards :-)