### PR TITLE
fix CMakeLists not finding Qt and breaking compatibility with Qt5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Network REQUIRED)
 
@@ -16,7 +17,7 @@ add_compile_options(-DSMTP_MIME_LIBRARY)
 
 message(USING Qt${QT_VERSION_MAJOR})
 
-qt_add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME} SHARED
     emailaddress.cpp
     mimeattachment.cpp
     mimebytearrayattachment.cpp


### PR DESCRIPTION
This library doesn't build with CMake, due to the lack of an instruction to look for and pick a Qt major version.

It is also advertised as being Qt5 compatible, but the `qt_add_library` command was introduced with Qt6. I don't know of a case in which such a Qt library wouldn't successfully build with CMake's own built-in command `add_library`, so I used it instead.