### PR TITLE
fix MimeMessage::formatAddress not protecting recipient names

### DIFF
--- a/src/mimemessage.cpp
+++ b/src/mimemessage.cpp
@@ -24,6 +24,15 @@
 #include "quotedprintable.h"
 #include "mimemultipart.h"
 #include <typeinfo>
+#include <iomanip>
+#include <sstream>
+
+static QByteArray quoteByteArray(const QByteArray& source)
+{
+  std::ostringstream stream;
+  stream << std::quoted(source.toStdString());
+  return QByteArray::fromStdString(stream.str());
+}
 
 /* [1] Constructors and Destructors */
 
@@ -175,7 +184,7 @@ QString MimeMessage::toString() const
 
 QByteArray MimeMessage::formatAddress(const EmailAddress &address, MimePart::Encoding encoding) {
     QByteArray result;
-    result.append(format(address.getName(), encoding));
+    result.append(quoteByteArray(format(address.getName(), encoding)));
     result.append((" <" + address.getAddress() + ">").toUtf8());
     return result;
 }


### PR DESCRIPTION
Greetings !

Right now, trying to send an email, to someone whose name contains a comma, results in a ClientError. According to the following topic :

https://stackoverflow.com/questions/15555563/how-to-format-an-email-from-header-that-contains-a-comma

... it seems that to prevent this issue, names in mail headers should be escaped using double quotes. This pull request achieves this result using stringstream and some iomanip magic. It does imply a back-and-forth conversion between QByteArray and std::string... but I don't believe Qt provides their own implementation for something like std::quoted, so this seemed like the simplest way to reach the goal.